### PR TITLE
Перевод кодировки ключей из cp1251 в юникод

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -30,33 +30,33 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 
 	//kinda localization -- rastaf0
-	//same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.
+	//same keys as above, but on russian keyboard layout. This file uses UTF-8 as encoding.
 	// Location
-	"ê" = MODE_R_HAND,
-	"ä" = MODE_L_HAND,
-	"ø" = MODE_INTERCOM,
+	"к" = MODE_R_HAND,
+	"д" = MODE_L_HAND,
+	"ш" = MODE_INTERCOM,
 
 	// Department
-	"ð" = MODE_DEPARTMENT,
-	"ñ" = RADIO_CHANNEL_COMMAND,
-	"ò" = RADIO_CHANNEL_SCIENCE,
-	"ü" = RADIO_CHANNEL_MEDICAL,
-	"ó" = RADIO_CHANNEL_ENGINEERING,
-	"û" = RADIO_CHANNEL_SECURITY,
-	"ã" = RADIO_CHANNEL_SUPPLY,
-	"ì" = RADIO_CHANNEL_SERVICE,
+	"р" = MODE_DEPARTMENT,
+	"с" = RADIO_CHANNEL_COMMAND,
+	"т" = RADIO_CHANNEL_SCIENCE,
+	"ь" = RADIO_CHANNEL_MEDICAL,
+	"у" = RADIO_CHANNEL_ENGINEERING,
+	"ы" = RADIO_CHANNEL_SECURITY,
+	"г" = RADIO_CHANNEL_SUPPLY,
+	"м" = RADIO_CHANNEL_SERVICE,
 
 	// Faction
-	"å" = RADIO_CHANNEL_SYNDICATE,
-	"í" = RADIO_CHANNEL_CENTCOM,
+	"е" = RADIO_CHANNEL_SYNDICATE,
+	"y" = RADIO_CHANNEL_CENTCOM,
 
 	// Admin
-	"ç" = MODE_ADMIN,
-	"â" = MODE_ADMIN,
+	"з" = MODE_ADMIN,
+	"в" = MODE_ADMIN,
 
 	// Misc
-	"ù" = RADIO_CHANNEL_AI_PRIVATE,
-	"÷" = MODE_VOCALCORDS
+	"щ" = RADIO_CHANNEL_AI_PRIVATE,
+	"ч" = MODE_VOCALCORDS
 ))
 
 /mob/living/proc/Ellipsis(original_msg, chance = 50, keep_words)
@@ -376,7 +376,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(clockslurring)
 		message = clockslur(message)
-   
+
 	// check for and apply punctuation
 	var/end = copytext(message, length(message))
 	if(!(end in list("!", ".", "?", ":", "\"", "-")))


### PR DESCRIPTION
На будущее: если кодировка слетит из-за балбеса который сидит с компилятора 512-ой версии, применить копипастом.
На данный момент всё выглядит так
		
		// Location
		"к" = MODE_R_HAND,
		"д" = MODE_L_HAND,
		"ш" = MODE_INTERCOM,

		// Department
		"р" = MODE_DEPARTMENT,
		"с" = RADIO_CHANNEL_COMMAND,
		"т" = RADIO_CHANNEL_SCIENCE,
		"ь" = RADIO_CHANNEL_MEDICAL,
		"у" = RADIO_CHANNEL_ENGINEERING,
		"ы" = RADIO_CHANNEL_SECURITY,
		"г" = RADIO_CHANNEL_SUPPLY,
		"м" = RADIO_CHANNEL_SERVICE,

		// Faction
		"е" = RADIO_CHANNEL_SYNDICATE,
		"y" = RADIO_CHANNEL_CENTCOM,

		// Admin
		"з" = MODE_ADMIN,
		"в" = MODE_ADMIN,

		// Misc
		"щ" = RADIO_CHANNEL_AI_PRIVATE,
		"ч" = MODE_VOCALCORDS