### PR TITLE
fix(radio): sanitize_cyrilic char to radio

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -158,6 +158,7 @@
 #include "code\__HELPERS\radio.dm"
 #include "code\__HELPERS\records.dm"
 #include "code\__HELPERS\roundend.dm"
+#include "code\__HELPERS\russian.dm"
 #include "code\__HELPERS\sanitize_values.dm"
 #include "code\__HELPERS\shell.dm"
 #include "code\__HELPERS\stat_helpers.dm"

--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -6,45 +6,45 @@
 #define RADIO_KEY_COMMON ";"
 
 #define RADIO_CHANNEL_SECURITY "Security"
-#define RADIO_KEY_SECURITY "s", "ы"
-#define RADIO_TOKEN_SECURITY ":s", ":ы"
+#define RADIO_KEY_SECURITY "s"
+#define RADIO_TOKEN_SECURITY ":s"
 
 #define RADIO_CHANNEL_ENGINEERING "Engineering"
-#define RADIO_KEY_ENGINEERING "e", "у"
-#define RADIO_TOKEN_ENGINEERING ":e", ":у"
+#define RADIO_KEY_ENGINEERING "e"
+#define RADIO_TOKEN_ENGINEERING ":e"
 
 #define RADIO_CHANNEL_COMMAND "Command"
-#define RADIO_KEY_COMMAND "c", "с"
-#define RADIO_TOKEN_COMMAND ":c", ":с"
+#define RADIO_KEY_COMMAND "c"
+#define RADIO_TOKEN_COMMAND ":c"
 
 #define RADIO_CHANNEL_SCIENCE "Science"
-#define RADIO_KEY_SCIENCE "n", "т"
-#define RADIO_TOKEN_SCIENCE ":n", ":т"
+#define RADIO_KEY_SCIENCE "n"
+#define RADIO_TOKEN_SCIENCE ":n"
 
 #define RADIO_CHANNEL_MEDICAL "Medical"
-#define RADIO_KEY_MEDICAL "m", "ь"
-#define RADIO_TOKEN_MEDICAL ":m", ":ь"
+#define RADIO_KEY_MEDICAL "m"
+#define RADIO_TOKEN_MEDICAL ":m"
 
 #define RADIO_CHANNEL_SUPPLY "Supply"
-#define RADIO_KEY_SUPPLY "u", "г"
-#define RADIO_TOKEN_SUPPLY ":u", ":г"
+#define RADIO_KEY_SUPPLY "u"
+#define RADIO_TOKEN_SUPPLY ":u"
 
 #define RADIO_CHANNEL_SERVICE "Service"
-#define RADIO_KEY_SERVICE "v", "м"
-#define RADIO_TOKEN_SERVICE ":v", ":м"
+#define RADIO_KEY_SERVICE "v"
+#define RADIO_TOKEN_SERVICE ":v"
 
 #define RADIO_CHANNEL_AI_PRIVATE "AI Private"
-#define RADIO_KEY_AI_PRIVATE "o", "щ"
-#define RADIO_TOKEN_AI_PRIVATE ":o", ":щ"
+#define RADIO_KEY_AI_PRIVATE "o"
+#define RADIO_TOKEN_AI_PRIVATE ":o"
 
 
 #define RADIO_CHANNEL_SYNDICATE "Syndicate"
-#define RADIO_KEY_SYNDICATE "t", "е"
-#define RADIO_TOKEN_SYNDICATE ":t", ":е"
+#define RADIO_KEY_SYNDICATE "t"
+#define RADIO_TOKEN_SYNDICATE ":t"
 
 #define RADIO_CHANNEL_CENTCOM "CentCom"
-#define RADIO_KEY_CENTCOM "y", "н"
-#define RADIO_TOKEN_CENTCOM ":y", ":н"
+#define RADIO_KEY_CENTCOM "y"
+#define RADIO_TOKEN_CENTCOM ":y"
 
 #define RADIO_CHANNEL_CTF_RED "Red Team"
 #define RADIO_CHANNEL_CTF_BLUE "Blue Team"

--- a/code/__HELPERS/russian.dm
+++ b/code/__HELPERS/russian.dm
@@ -1,0 +1,17 @@
+GLOBAL_LIST_INIT(rkeys, list(
+	"а" = "f", "в" = "d", "г" = "u", "д" = "l",
+	"е" = "t", "з" = "p", "и" = "b", "й" = "q",
+	"к" = "r", "л" = "k", "м" = "v", "н" = "y",
+	"о" = "j", "п" = "g", "р" = "h", "с" = "c",
+	"т" = "n", "у" = "e", "ф" = "a", "ц" = "w",
+	"ч" = "x", "ш" = "i", "щ" = "o", "ы" = "s",
+	"ь" = "m", "я" = "z"
+))
+
+
+// Transform keys from russian keyboard layout to eng analogues and lowertext it.
+/proc/sanitize_cyrillic_char(t)
+	t = lowertext(t)
+	if(t in GLOB.rkeys)
+		return GLOB.rkeys[t]
+	return t

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -122,7 +122,7 @@
 			mods[MODE_HEADSET] = TRUE
 		else if((key in GLOB.department_radio_prefixes) && length(message) > length(key) + 1 && !mods[RADIO_EXTENSION])
 			mods[RADIO_KEY] = lowertext(message[1 + length(key)])
-			mods[RADIO_EXTENSION] = GLOB.department_radio_keys[mods[RADIO_KEY]]
+			mods[RADIO_EXTENSION] = GLOB.department_radio_keys[sanitize_cyrillic_char(mods[RADIO_KEY])]
 			chop_to = length(key) + 2
 		else if(key == "," && !mods[LANGUAGE_EXTENSION])
 			for(var/ld in GLOB.all_languages)


### PR DESCRIPTION
Радио теперь юзается в обеих случаях как русской буквы, так и английской

https://user-images.githubusercontent.com/42303535/130334582-b7784656-e54b-4a7a-a5e0-874675acabc7.mp4

## Changelog
fix: Радио теперь работает при обеих префиксах как русской буквы, так и английской
/:cl: